### PR TITLE
fix mechanics around block and branch operations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,14 @@ jobs:
 
       - name: Install dependencies
         run: dart pub get
-  
+
+      - name: Show generated file sizes
+        run: |
+          echo "File sizes in KB"
+          echo ""
+          ls -skS -1 -R test/spec/**/*.dart
+          ls -skS -1 -R samples/**/*.dart
+
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
           echo "File sizes in KB"
           echo ""
           ls -skS -1 -R test/spec/**/*.dart
-          ls -skS -1 -R samples/**/*.dart
+          ls -skS -1 -R samples/*.dart
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -226,6 +226,17 @@ class Frame {
     return stack.last as T;
   }
 
+  /// Remove all but the oldest [depth] stack entries, but keep the top
+  /// [paramCount] stack items.
+  void unwindTo(int depth, int paramCount) {
+    if (stack.length == depth + paramCount) {
+      return;
+    }
+
+    // Keep [0, start), [length-paramCount, length)
+    stack.removeRange(depth, stack.length - paramCount);
+  }
+
   void drop() {
     stack.removeLast();
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -29,8 +29,16 @@ String patchUpName(String name) {
   if (isNumber(name.codeUnits[0])) {
     return '\$$name';
   }
+  if (_keywords.contains(name)) {
+    return '\$$name';
+  }
   return name;
 }
+
+const Set<String> _keywords = {
+  'for',
+  'while',
+};
 
 String titleCase(String name) {
   return name.split('_').map((s) {

--- a/samples/gcd.dart
+++ b/samples/gcd.dart
@@ -23,9 +23,13 @@ class GcdModule implements Module {
       block_label_1:
       {
         frame.push(arg0);
-        if (frame.pop() != 0) break block_label_1;
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_1;
+        }
         frame.push(arg1);
         local0 = frame.pop();
+        frame.unwindTo(0, 0);
         break block_label_0;
       }
 
@@ -39,7 +43,9 @@ class GcdModule implements Module {
         frame.push(local0);
         arg1 = frame.pop();
         frame.push(arg0);
-        if (frame.pop() != 0) continue loop_label_1;
+        if (frame.pop() != 0) {
+          continue loop_label_1;
+        }
         break;
       }
     }

--- a/test/spec/br_if/br_if.0.dart
+++ b/test/spec/br_if/br_if.0.dart
@@ -1,0 +1,1294 @@
+// Generated from test/spec/br_if/br_if.0.wasm.
+
+// ignore_for_file: camel_case_types, dead_code, non_constant_identifier_names
+// ignore_for_file: unused_element, unused_label, unused_local_variable
+
+import 'package:wasmd/runtime.dart';
+
+class BrIf0Module implements Module {
+  BrIf0Module() {
+    segments.init();
+  }
+
+  @override
+  final Memory memory = Memory(1);
+
+  final Globals globals = Globals();
+
+  final Table table0 = Table(
+    1,
+    1,
+  );
+
+  @override
+  late final List<Table> tables = [table0];
+
+  late final ElementSegments segments = ElementSegments(this);
+
+  late final List<Function> functionTable = _initFunctionTable();
+
+  void dummy() {
+    final frame = Frame(this);
+  }
+
+  void type_i32() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.i32_ctz();
+      frame.drop();
+    }
+  }
+
+  void type_i64() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i64_const(0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.i64_ctz();
+      frame.drop();
+    }
+  }
+
+  void type_f32() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.f32_const(0.0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.f32_neg();
+      frame.drop();
+    }
+  }
+
+  void type_f64() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.f64_const(0.0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.f64_neg();
+      frame.drop();
+    }
+  }
+
+  i32 type_i32_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_ctz();
+    }
+    return frame.pop();
+  }
+
+  i64 type_i64_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i64_const(2);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i64_ctz();
+    }
+    return frame.pop();
+  }
+
+  f32 type_f32_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.f32_const(3.0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.f32_neg();
+    }
+    return frame.pop();
+  }
+
+  f64 type_f64_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.f64_const(4.0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.f64_neg();
+    }
+    return frame.pop();
+  }
+
+  i32 as_block_first(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.i32_const(2);
+      return frame.pop();
+    }
+    frame.i32_const(3);
+    return frame.pop();
+  }
+
+  i32 as_block_mid(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      dummy();
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      frame.i32_const(2);
+      return frame.pop();
+    }
+    frame.i32_const(3);
+    return frame.pop();
+  }
+
+  void as_block_last(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      dummy();
+      dummy();
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+    }
+  }
+
+  i32 as_block_first_value(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(10);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(11);
+      return frame.pop();
+    }
+    return frame.pop();
+  }
+
+  i32 as_block_mid_value(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      dummy();
+      frame.i32_const(20);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(21);
+      return frame.pop();
+    }
+    return frame.pop();
+  }
+
+  i32 as_block_last_value(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      dummy();
+      dummy();
+      frame.i32_const(11);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_loop_first(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      loop_label_1:
+      for (;;) {
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
+        frame.i32_const(2);
+        return frame.pop();
+        break;
+      }
+    }
+    frame.i32_const(3);
+    return frame.pop();
+  }
+
+  i32 as_loop_mid(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      loop_label_1:
+      for (;;) {
+        dummy();
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
+        frame.i32_const(2);
+        return frame.pop();
+        break;
+      }
+    }
+    frame.i32_const(4);
+    return frame.pop();
+  }
+
+  void as_loop_last(i32 arg0) {
+    final frame = Frame(this);
+
+    loop_label_0:
+    for (;;) {
+      dummy();
+      frame.push(arg0);
+      return;
+      break;
+    }
+  }
+
+  i32 as_br_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.unwindTo(0, 1);
+      break block_label_0;
+    }
+    return frame.pop();
+  }
+
+  void as_br_if_cond() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+    }
+  }
+
+  i32 as_br_if_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(3);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(4);
+    }
+    return frame.pop();
+  }
+
+  i32 as_br_if_value_cond(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.i32_const(1);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(4);
+    }
+    return frame.pop();
+  }
+
+  void as_br_table_index() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
+      var t0 = frame.pop();
+      switch (t0) {
+        case 0:
+          frame.unwindTo(0, 0);
+          break block_label_0;
+
+        case 1:
+          frame.unwindTo(0, 0);
+          break block_label_0;
+
+        default:
+          frame.unwindTo(0, 0);
+          break block_label_0;
+      }
+    }
+  }
+
+  i32 as_br_table_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(3);
+      var t0 = frame.pop();
+      switch (t0) {
+        case 0:
+          frame.unwindTo(0, 1);
+          break block_label_0;
+
+        case 1:
+          frame.unwindTo(0, 1);
+          break block_label_0;
+
+        default:
+          frame.unwindTo(0, 1);
+          break block_label_0;
+      }
+
+      frame.i32_const(4);
+    }
+    return frame.pop();
+  }
+
+  i32 as_br_table_value_index() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.i32_const(1);
+      frame.i32_const(3);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      var t0 = frame.pop();
+      switch (t0) {
+        case 0:
+          frame.unwindTo(0, 1);
+          break block_label_0;
+
+        default:
+          frame.unwindTo(0, 1);
+          break block_label_0;
+      }
+
+      frame.i32_const(4);
+    }
+    return frame.pop();
+  }
+
+  i64 as_return_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i64_const(1);
+      frame.i32_const(2);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      return frame.pop();
+    }
+    return frame.pop();
+  }
+
+  i32 as_if_cond(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      if_label_1:
+      if (frame.pop() != 0) {
+        frame.i32_const(2);
+      } else {
+        frame.i32_const(3);
+      }
+    }
+    return frame.pop();
+  }
+
+  void as_if_then(i32 arg0, i32 arg1) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.push(arg0);
+      if_label_1:
+      if (frame.pop() != 0) {
+        frame.push(arg1);
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
+      } else {
+        dummy();
+      }
+    }
+  }
+
+  void as_if_else(i32 arg0, i32 arg1) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.push(arg0);
+      if_label_1:
+      if (frame.pop() != 0) {
+        dummy();
+      } else {
+        frame.push(arg1);
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
+      }
+    }
+  }
+
+  i32 as_select_first(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(3);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(2);
+      frame.push(arg0);
+      frame.select();
+    }
+    return frame.pop();
+  }
+
+  i32 as_select_second(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(3);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.push(arg0);
+      frame.select();
+    }
+    return frame.pop();
+  }
+
+  i32 as_select_cond() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      frame.i32_const(3);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.select();
+    }
+    return frame.pop();
+  }
+
+  i32 f(i32 arg0, i32 arg1, i32 arg2) {
+    final frame = Frame(this);
+    frame.i32_const(-1);
+    return frame.pop();
+  }
+
+  i32 as_call_first() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(12);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(2);
+      frame.i32_const(3);
+      {
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(f(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_call_mid() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(13);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(3);
+      {
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(f(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_call_last() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      frame.i32_const(14);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      {
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(f(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 func(i32 arg0, i32 arg1, i32 arg2) {
+    final frame = Frame(this);
+    frame.push(arg0);
+    return frame.pop();
+  }
+
+  i32 as_call_indirect_func() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(4);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(1);
+      frame.i32_const(2);
+      frame.i32_const(0);
+      {
+        var func = table0[frame.pop()] as FunctionType0?;
+        if (func == null) throw Trap('uninitialized element');
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(func(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_call_indirect_first() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(4);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(2);
+      frame.i32_const(0);
+      {
+        var func = table0[frame.pop()] as FunctionType0?;
+        if (func == null) throw Trap('uninitialized element');
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(func(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_call_indirect_mid() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      frame.i32_const(4);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(0);
+      {
+        var func = table0[frame.pop()] as FunctionType0?;
+        if (func == null) throw Trap('uninitialized element');
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(func(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_call_indirect_last() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(2);
+      frame.i32_const(3);
+      frame.i32_const(4);
+      frame.i32_const(10);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      {
+        var func = table0[frame.pop()] as FunctionType0?;
+        if (func == null) throw Trap('uninitialized element');
+        var t2 = frame.pop();
+        var t1 = frame.pop();
+        var t0 = frame.pop();
+        frame.push(func(t0, t1, t2));
+      }
+    }
+    return frame.pop();
+  }
+
+  i32 as_local_set_value(i32 arg0) {
+    i32 local0 = 0;
+
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(17);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      arg0 = frame.pop();
+      frame.i32_const(-1);
+    }
+    return frame.pop();
+  }
+
+  i32 as_local_tee_value(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      arg0 = frame.peek();
+      frame.i32_const(-1);
+      return frame.pop();
+    }
+    return frame.pop();
+  }
+
+  i32 as_global_set_value(i32 arg0) {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.push(arg0);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      globals.a = frame.pop();
+      frame.i32_const(-1);
+      return frame.pop();
+    }
+    return frame.pop();
+  }
+
+  i32 as_load_address() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_load(2, 0);
+    }
+    return frame.pop();
+  }
+
+  i32 as_loadN_address() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(30);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_load8_s(0, 0);
+    }
+    return frame.pop();
+  }
+
+  i32 as_store_address() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(30);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(7);
+      frame.i32_store(2, 0);
+      frame.i32_const(-1);
+    }
+    return frame.pop();
+  }
+
+  i32 as_store_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.i32_const(31);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_store(2, 0);
+      frame.i32_const(-1);
+    }
+    return frame.pop();
+  }
+
+  i32 as_storeN_address() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(32);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(7);
+      frame.i32_store8(0, 0);
+      frame.i32_const(-1);
+    }
+    return frame.pop();
+  }
+
+  i32 as_storeN_value() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.i32_const(33);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_store16(1, 0);
+      frame.i32_const(-1);
+    }
+    return frame.pop();
+  }
+
+  f64 as_unary_operand() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.f64_const(1.0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.f64_neg();
+    }
+    return frame.pop();
+  }
+
+  i32 as_binary_left() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(10);
+      frame.i32_add();
+    }
+    return frame.pop();
+  }
+
+  i32 as_binary_right() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(10);
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_sub();
+    }
+    return frame.pop();
+  }
+
+  i32 as_test_operand() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(0);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_eqz();
+    }
+    return frame.pop();
+  }
+
+  i32 as_compare_left() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_const(10);
+      frame.i32_le_u();
+    }
+    return frame.pop();
+  }
+
+  i32 as_compare_right() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(10);
+      frame.i32_const(1);
+      frame.i32_const(42);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.i32_ne();
+    }
+    return frame.pop();
+  }
+
+  i32 as_memory_grow_size() {
+    final frame = Frame(this);
+    block_label_0:
+    {
+      frame.i32_const(1);
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
+      frame.memory_grow(0);
+    }
+    return frame.pop();
+  }
+
+  i32 nested_block_value(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      frame.i32_const(4);
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(16);
+      }
+      frame.i32_add();
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  i32 nested_br_value(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(4);
+      }
+      frame.unwindTo(1, 1);
+      break block_label_0;
+
+      frame.i32_const(16);
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  i32 nested_br_if_value(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(4);
+      }
+      frame.i32_const(1);
+      if (frame.pop() != 0) {
+        frame.unwindTo(1, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(16);
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  i32 nested_br_if_value_cond(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      frame.i32_const(4);
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(1);
+      }
+      if (frame.pop() != 0) {
+        frame.unwindTo(1, 1);
+        break block_label_0;
+      }
+      frame.drop();
+      frame.i32_const(16);
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  i32 nested_br_table_value(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(4);
+      }
+      frame.i32_const(1);
+      var t0 = frame.pop();
+      switch (t0) {
+        default:
+          frame.unwindTo(1, 1);
+          break block_label_0;
+      }
+
+      frame.i32_const(16);
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  i32 nested_br_table_value_index(i32 arg0) {
+    final frame = Frame(this);
+    frame.i32_const(1);
+    block_label_0:
+    {
+      frame.i32_const(2);
+      frame.drop();
+      frame.i32_const(4);
+      block_label_1:
+      {
+        frame.i32_const(8);
+        frame.push(arg0);
+        if (frame.pop() != 0) {
+          frame.unwindTo(1, 1);
+          break block_label_0;
+        }
+        frame.drop();
+        frame.i32_const(1);
+      }
+      var t0 = frame.pop();
+      switch (t0) {
+        default:
+          frame.unwindTo(1, 1);
+          break block_label_0;
+      }
+
+      frame.i32_const(16);
+    }
+    frame.i32_add();
+    return frame.pop();
+  }
+
+  List<Function> _initFunctionTable() {
+    return [
+      dummy,
+      type_i32,
+      type_i64,
+      type_f32,
+      type_f64,
+      type_i32_value,
+      type_i64_value,
+      type_f32_value,
+      type_f64_value,
+      as_block_first,
+      as_block_mid,
+      as_block_last,
+      as_block_first_value,
+      as_block_mid_value,
+      as_block_last_value,
+      as_loop_first,
+      as_loop_mid,
+      as_loop_last,
+      as_br_value,
+      as_br_if_cond,
+      as_br_if_value,
+      as_br_if_value_cond,
+      as_br_table_index,
+      as_br_table_value,
+      as_br_table_value_index,
+      as_return_value,
+      as_if_cond,
+      as_if_then,
+      as_if_else,
+      as_select_first,
+      as_select_second,
+      as_select_cond,
+      f,
+      as_call_first,
+      as_call_mid,
+      as_call_last,
+      func,
+      as_call_indirect_func,
+      as_call_indirect_first,
+      as_call_indirect_mid,
+      as_call_indirect_last,
+      as_local_set_value,
+      as_local_tee_value,
+      as_global_set_value,
+      as_load_address,
+      as_loadN_address,
+      as_store_address,
+      as_store_value,
+      as_storeN_address,
+      as_storeN_value,
+      as_unary_operand,
+      as_binary_left,
+      as_binary_right,
+      as_test_operand,
+      as_compare_left,
+      as_compare_right,
+      as_memory_grow_size,
+      nested_block_value,
+      nested_br_value,
+      nested_br_if_value,
+      nested_br_if_value_cond,
+      nested_br_table_value,
+      nested_br_table_value_index
+    ];
+  }
+}
+
+typedef FunctionType0 = i32 Function(i32, i32, i32);
+typedef FunctionType1 = void Function();
+typedef FunctionType2 = i32 Function();
+typedef FunctionType3 = i64 Function();
+typedef FunctionType4 = f32 Function();
+typedef FunctionType5 = f64 Function();
+typedef FunctionType6 = i32 Function(i32);
+typedef FunctionType7 = void Function(i32);
+typedef FunctionType8 = void Function(i32, i32);
+
+class Globals {
+  i32 a = 10;
+}
+
+class ElementSegments extends AbstractElementSegments {
+  ElementSegments(this.module);
+
+  final BrIf0Module module;
+
+  @override
+  List<Function> get functionTable => module.functionTable;
+
+  void init() {
+    copyTo(module.table0, 0, 0, 1, [36]); /* segment0 */
+  }
+}

--- a/test/spec/br_if/br_if_test.dart
+++ b/test/spec/br_if/br_if_test.dart
@@ -1,0 +1,146 @@
+// Generated from spec/test/core/br_if.wast.
+
+// ignore_for_file: non_constant_identifier_names, unused_local_variable
+
+import '../../src/infra.dart';
+import 'br_if.0.dart' as br_if_0;
+
+void main() {
+  group('br_if', () {
+    // module br_if.0.dart (line 3)
+    var m0 = br_if_0.BrIf0Module();
+
+    returns('type_i32_0', () => m0.type_i32(), null);
+    returns('type_i64_0', () => m0.type_i64(), null);
+    returns('type_f32_0', () => m0.type_f32(), null);
+    returns('type_f64_0', () => m0.type_f64(), null);
+    returns('type_i32_value_0', () => m0.type_i32_value(), 0x1);
+    returns('type_i64_value_0', () => m0.type_i64_value(), 0x2);
+    returns('type_f32_value_0', () => m0.type_f32_value(), f32('40400000'));
+    returns(
+      'type_f64_value_0',
+      () => m0.type_f64_value(),
+      f64('4010000000000000'),
+    );
+    returns('as_block_first_0', () => m0.as_block_first(0), 0x2);
+    returns('as_block_first_1', () => m0.as_block_first(0x1), 0x3);
+    returns('as_block_mid_0', () => m0.as_block_mid(0), 0x2);
+    returns('as_block_mid_1', () => m0.as_block_mid(0x1), 0x3);
+    returns('as_block_last_0', () => m0.as_block_last(0), null);
+    returns('as_block_last_1', () => m0.as_block_last(0x1), null);
+    returns('as_block_first_value_0', () => m0.as_block_first_value(0), 0xB);
+    returns('as_block_first_value_1', () => m0.as_block_first_value(0x1), 0xA);
+    returns('as_block_mid_value_0', () => m0.as_block_mid_value(0), 0x15);
+    returns('as_block_mid_value_1', () => m0.as_block_mid_value(0x1), 0x14);
+    returns('as_block_last_value_0', () => m0.as_block_last_value(0), 0xB);
+    returns('as_block_last_value_1', () => m0.as_block_last_value(0x1), 0xB);
+    returns('as_loop_first_0', () => m0.as_loop_first(0), 0x2);
+    returns('as_loop_first_1', () => m0.as_loop_first(0x1), 0x3);
+    returns('as_loop_mid_0', () => m0.as_loop_mid(0), 0x2);
+    returns('as_loop_mid_1', () => m0.as_loop_mid(0x1), 0x4);
+    returns('as_loop_last_0', () => m0.as_loop_last(0), null);
+    returns('as_loop_last_1', () => m0.as_loop_last(0x1), null);
+    returns('as_br_value_0', () => m0.as_br_value(), 0x1);
+    returns('as_br_if_cond_0', () => m0.as_br_if_cond(), null);
+    returns('as_br_if_value_0', () => m0.as_br_if_value(), 0x1);
+    returns('as_br_if_value_cond_0', () => m0.as_br_if_value_cond(0), 0x2);
+    returns('as_br_if_value_cond_1', () => m0.as_br_if_value_cond(0x1), 0x1);
+    returns('as_br_table_index_0', () => m0.as_br_table_index(), null);
+    returns('as_br_table_value_0', () => m0.as_br_table_value(), 0x1);
+    returns(
+      'as_br_table_value_index_0',
+      () => m0.as_br_table_value_index(),
+      0x1,
+    );
+    returns('as_return_value_0', () => m0.as_return_value(), 0x1);
+    returns('as_if_cond_0', () => m0.as_if_cond(0), 0x2);
+    returns('as_if_cond_1', () => m0.as_if_cond(0x1), 0x1);
+    returns('as_if_then_0', () => m0.as_if_then(0, 0), null);
+    returns('as_if_then_1', () => m0.as_if_then(0x4, 0), null);
+    returns('as_if_then_2', () => m0.as_if_then(0, 0x1), null);
+    returns('as_if_then_3', () => m0.as_if_then(0x4, 0x1), null);
+    returns('as_if_else_0', () => m0.as_if_else(0, 0), null);
+    returns('as_if_else_1', () => m0.as_if_else(0x3, 0), null);
+    returns('as_if_else_2', () => m0.as_if_else(0, 0x1), null);
+    returns('as_if_else_3', () => m0.as_if_else(0x3, 0x1), null);
+    returns('as_select_first_0', () => m0.as_select_first(0), 0x3);
+    returns('as_select_first_1', () => m0.as_select_first(0x1), 0x3);
+    returns('as_select_second_0', () => m0.as_select_second(0), 0x3);
+    returns('as_select_second_1', () => m0.as_select_second(0x1), 0x3);
+    returns('as_select_cond_0', () => m0.as_select_cond(), 0x3);
+    returns('as_call_first_0', () => m0.as_call_first(), 0xC);
+    returns('as_call_mid_0', () => m0.as_call_mid(), 0xD);
+    returns('as_call_last_0', () => m0.as_call_last(), 0xE);
+    returns('as_call_indirect_func_0', () => m0.as_call_indirect_func(), 0x4);
+    returns('as_call_indirect_first_0', () => m0.as_call_indirect_first(), 0x4);
+    returns('as_call_indirect_mid_0', () => m0.as_call_indirect_mid(), 0x4);
+    returns('as_call_indirect_last_0', () => m0.as_call_indirect_last(), 0x4);
+    returns(
+      'as_local_set_value_0',
+      () => m0.as_local_set_value(0),
+      i32('FFFFFFFF'),
+    );
+    returns('as_local_set_value_1', () => m0.as_local_set_value(0x1), 0x11);
+    returns(
+      'as_local_tee_value_0',
+      () => m0.as_local_tee_value(0),
+      i32('FFFFFFFF'),
+    );
+    returns('as_local_tee_value_1', () => m0.as_local_tee_value(0x1), 0x1);
+    returns(
+      'as_global_set_value_0',
+      () => m0.as_global_set_value(0),
+      i32('FFFFFFFF'),
+    );
+    returns('as_global_set_value_1', () => m0.as_global_set_value(0x1), 0x1);
+    returns('as_load_address_0', () => m0.as_load_address(), 0x1);
+    returns('as_loadN_address_0', () => m0.as_loadN_address(), 0x1E);
+    returns('as_store_address_0', () => m0.as_store_address(), 0x1E);
+    returns('as_store_value_0', () => m0.as_store_value(), 0x1F);
+    returns('as_storeN_address_0', () => m0.as_storeN_address(), 0x20);
+    returns('as_storeN_value_0', () => m0.as_storeN_value(), 0x21);
+    returns(
+      'as_unary_operand_0',
+      () => m0.as_unary_operand(),
+      f64('3FF0000000000000'),
+    );
+    returns('as_binary_left_0', () => m0.as_binary_left(), 0x1);
+    returns('as_binary_right_0', () => m0.as_binary_right(), 0x1);
+    returns('as_test_operand_0', () => m0.as_test_operand(), 0);
+    returns('as_compare_left_0', () => m0.as_compare_left(), 0x1);
+    returns('as_compare_right_0', () => m0.as_compare_right(), 0x1);
+    returns('as_memory_grow_size_0', () => m0.as_memory_grow_size(), 0x1);
+    returns('nested_block_value_0', () => m0.nested_block_value(0), 0x15);
+    returns('nested_block_value_1', () => m0.nested_block_value(0x1), 0x9);
+    returns('nested_br_value_0', () => m0.nested_br_value(0), 0x5);
+    returns('nested_br_value_1', () => m0.nested_br_value(0x1), 0x9);
+    returns('nested_br_if_value_0', () => m0.nested_br_if_value(0), 0x5);
+    returns('nested_br_if_value_1', () => m0.nested_br_if_value(0x1), 0x9);
+    returns(
+      'nested_br_if_value_cond_0',
+      () => m0.nested_br_if_value_cond(0),
+      0x5,
+    );
+    returns(
+      'nested_br_if_value_cond_1',
+      () => m0.nested_br_if_value_cond(0x1),
+      0x9,
+    );
+    returns('nested_br_table_value_0', () => m0.nested_br_table_value(0), 0x5);
+    returns(
+      'nested_br_table_value_1',
+      () => m0.nested_br_table_value(0x1),
+      0x9,
+    );
+    returns(
+      'nested_br_table_value_index_0',
+      () => m0.nested_br_table_value_index(0),
+      0x5,
+    );
+    returns(
+      'nested_br_table_value_index_1',
+      () => m0.nested_br_table_value_index(0x1),
+      0x9,
+    );
+  });
+}

--- a/test/spec/left-to-right/left_to_right.0.dart
+++ b/test/spec/left-to-right/left_to_right.0.dart
@@ -1389,7 +1389,10 @@ class LeftToRight0Module implements Module {
       frame.push(i32_right());
       frame.i32_const(0);
       frame.i32_and();
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.push(get());
     }
@@ -1408,8 +1411,11 @@ class LeftToRight0Module implements Module {
         var t0 = frame.pop();
         switch (t0) {
           case 0:
+            frame.unwindTo(0, 1);
             break block_label_0;
+
           default:
+            frame.unwindTo(0, 1);
             break block_label_1;
         }
       }

--- a/test/spec/load/load.0.dart
+++ b/test/spec/load/load.0.dart
@@ -33,6 +33,7 @@ class Load0Module implements Module {
     {
       frame.i32_const(0);
       frame.i32_load(2, 0);
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -44,7 +45,10 @@ class Load0Module implements Module {
     {
       frame.i32_const(0);
       frame.i32_load(2, 0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -55,7 +59,10 @@ class Load0Module implements Module {
       frame.i32_const(0);
       frame.i32_load(2, 0);
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -69,7 +76,10 @@ class Load0Module implements Module {
       frame.i32_const(6);
       frame.i32_const(0);
       frame.i32_load(2, 0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -85,10 +95,15 @@ class Load0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }
@@ -104,10 +119,15 @@ class Load0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 
@@ -126,8 +146,11 @@ class Load0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 

--- a/test/spec/local_get/local_get.0.dart
+++ b/test/spec/local_get/local_get.0.dart
@@ -171,6 +171,7 @@ class LocalGet0Module implements Module {
     block_label_0:
     {
       frame.push(arg0);
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -182,7 +183,10 @@ class LocalGet0Module implements Module {
     {
       frame.push(arg0);
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -193,7 +197,10 @@ class LocalGet0Module implements Module {
     {
       frame.push(arg0);
       frame.push(arg0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -210,10 +217,15 @@ class LocalGet0Module implements Module {
           var t0 = frame.pop();
           switch (t0) {
             case 0:
+              frame.unwindTo(0, 0);
               break block_label_2;
+
             case 1:
+              frame.unwindTo(0, 0);
               break block_label_1;
+
             default:
+              frame.unwindTo(0, 0);
               break block_label_0;
           }
 

--- a/test/spec/local_set/local_set.0.dart
+++ b/test/spec/local_set/local_set.0.dart
@@ -170,6 +170,7 @@ class LocalSet0Module implements Module {
     {
       frame.i32_const(9);
       arg0 = frame.pop();
+      frame.unwindTo(0, 0);
       break block_label_0;
     }
   }
@@ -181,7 +182,10 @@ class LocalSet0Module implements Module {
       frame.i32_const(8);
       arg0 = frame.pop();
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -192,7 +196,10 @@ class LocalSet0Module implements Module {
       frame.i32_const(6);
       frame.i32_const(9);
       arg0 = frame.pop();
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -206,6 +213,7 @@ class LocalSet0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }

--- a/test/spec/local_tee/local_tee.0.dart
+++ b/test/spec/local_tee/local_tee.0.dart
@@ -318,6 +318,7 @@ class LocalTee0Module implements Module {
     {
       frame.i32_const(9);
       arg0 = frame.peek();
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -329,7 +330,10 @@ class LocalTee0Module implements Module {
     {
       frame.i32_const(1);
       arg0 = frame.peek();
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -340,7 +344,10 @@ class LocalTee0Module implements Module {
       frame.i32_const(8);
       arg0 = frame.peek();
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -354,7 +361,10 @@ class LocalTee0Module implements Module {
       frame.i32_const(6);
       frame.i32_const(9);
       arg0 = frame.peek();
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -370,10 +380,15 @@ class LocalTee0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }
@@ -389,10 +404,15 @@ class LocalTee0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 
@@ -411,8 +431,11 @@ class LocalTee0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 

--- a/test/spec/memory_grow/memory_grow.3.dart
+++ b/test/spec/memory_grow/memory_grow.3.dart
@@ -37,11 +37,17 @@ class MemoryGrow3Module implements Module {
         frame.push(local0);
         frame.i32_const(0);
         frame.i32_ne();
-        if (frame.pop() != 0) break block_label_0;
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
         frame.push(arg0);
         frame.push(arg1);
         frame.i32_ge_u();
-        if (frame.pop() != 0) break block_label_0;
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
         frame.push(arg0);
         frame.i32_const(1);
         frame.i32_add();
@@ -49,7 +55,9 @@ class MemoryGrow3Module implements Module {
         frame.push(arg0);
         frame.push(arg1);
         frame.i32_le_u();
-        if (frame.pop() != 0) continue loop_label_1;
+        if (frame.pop() != 0) {
+          continue loop_label_1;
+        }
         break;
       }
     }

--- a/test/spec/memory_grow/memory_grow.4.dart
+++ b/test/spec/memory_grow/memory_grow.4.dart
@@ -33,6 +33,7 @@ class MemoryGrow4Module implements Module {
     {
       frame.i32_const(0);
       frame.memory_grow(0);
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -44,7 +45,10 @@ class MemoryGrow4Module implements Module {
     {
       frame.i32_const(0);
       frame.memory_grow(0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -55,7 +59,10 @@ class MemoryGrow4Module implements Module {
       frame.i32_const(0);
       frame.memory_grow(0);
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -69,7 +76,10 @@ class MemoryGrow4Module implements Module {
       frame.i32_const(6);
       frame.i32_const(0);
       frame.memory_grow(0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -85,10 +95,15 @@ class MemoryGrow4Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }
@@ -104,10 +119,15 @@ class MemoryGrow4Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 
@@ -126,8 +146,11 @@ class MemoryGrow4Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 

--- a/test/spec/nop/nop.0.dart
+++ b/test/spec/nop/nop.0.dart
@@ -297,6 +297,7 @@ class Nop0Module implements Module {
     {
       /* nop */
       frame.push(arg0);
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -308,6 +309,7 @@ class Nop0Module implements Module {
     {
       frame.push(arg0);
       /* nop */
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -322,6 +324,7 @@ class Nop0Module implements Module {
       frame.push(arg0);
       /* nop */
       /* nop */
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -334,7 +337,10 @@ class Nop0Module implements Module {
       /* nop */
       frame.push(arg0);
       frame.push(arg0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -346,7 +352,10 @@ class Nop0Module implements Module {
       frame.push(arg0);
       /* nop */
       frame.push(arg0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -358,7 +367,10 @@ class Nop0Module implements Module {
       frame.push(arg0);
       frame.push(arg0);
       /* nop */
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -375,7 +387,10 @@ class Nop0Module implements Module {
       frame.push(arg0);
       /* nop */
       /* nop */
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
     }
     return frame.pop();
   }
@@ -390,8 +405,11 @@ class Nop0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
     }
@@ -408,8 +426,11 @@ class Nop0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
     }
@@ -426,8 +447,11 @@ class Nop0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
     }
@@ -449,8 +473,11 @@ class Nop0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
     }

--- a/test/spec/return/return.0.dart
+++ b/test/spec/return/return.0.dart
@@ -232,6 +232,7 @@ class Return0Module implements Module {
     {
       frame.i32_const(9);
       return frame.pop();
+      frame.unwindTo(0, 1);
       break block_label_0;
     }
     return frame.pop();
@@ -241,7 +242,10 @@ class Return0Module implements Module {
     final frame = Frame(this);
     block_label_0:
     {
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -252,7 +256,10 @@ class Return0Module implements Module {
       frame.i32_const(8);
       return frame.pop();
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -266,7 +273,10 @@ class Return0Module implements Module {
       frame.i32_const(6);
       frame.i32_const(9);
       return frame.pop();
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 1);
+        break block_label_0;
+      }
       frame.drop();
       frame.i32_const(7);
     }
@@ -282,10 +292,15 @@ class Return0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 0);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }
@@ -303,10 +318,15 @@ class Return0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         case 1:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 
@@ -325,8 +345,11 @@ class Return0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         case 0:
+          frame.unwindTo(0, 1);
           break block_label_0;
+
         default:
+          frame.unwindTo(0, 1);
           break block_label_0;
       }
 

--- a/test/spec/stack/stack.0.dart
+++ b/test/spec/stack/stack.0.dart
@@ -34,6 +34,7 @@ class Stack0Module implements Module {
         frame.i64_eq();
         if_label_2:
         if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
           break block_label_0;
         } else {
           frame.push(i);
@@ -46,6 +47,7 @@ class Stack0Module implements Module {
           i = frame.pop();
         }
         continue loop_label_1;
+
         break;
       }
     }
@@ -71,6 +73,7 @@ class Stack0Module implements Module {
         frame.i64_eq();
         if_label_2:
         if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
           break block_label_0;
         } else {
           frame.push(i);
@@ -83,6 +86,7 @@ class Stack0Module implements Module {
           i = frame.pop();
         }
         continue loop_label_1;
+
         break;
       }
     }
@@ -108,6 +112,7 @@ class Stack0Module implements Module {
         frame.i64_eq();
         if_label_2:
         if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
           break block_label_0;
         } else {
           frame.push(i);
@@ -120,6 +125,7 @@ class Stack0Module implements Module {
           i = frame.pop();
         }
         continue loop_label_1;
+
         break;
       }
     }
@@ -145,6 +151,7 @@ class Stack0Module implements Module {
         frame.i64_eq();
         if_label_2:
         if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
           break block_label_0;
         } else {
           frame.push(i);
@@ -157,6 +164,7 @@ class Stack0Module implements Module {
           i = frame.pop();
         }
         continue loop_label_1;
+
         break;
       }
     }
@@ -182,6 +190,7 @@ class Stack0Module implements Module {
         frame.i64_eq();
         if_label_2:
         if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
           break block_label_0;
         } else {
           frame.push(i);
@@ -194,6 +203,7 @@ class Stack0Module implements Module {
           i = frame.pop();
         }
         continue loop_label_1;
+
         break;
       }
     }

--- a/test/spec/store/store.0.dart
+++ b/test/spec/store/store.0.dart
@@ -43,6 +43,7 @@ class Store0Module implements Module {
       frame.i32_const(0);
       frame.i32_const(1);
       frame.i32_store(2, 0);
+      frame.unwindTo(0, 0);
       break block_label_0;
     }
   }
@@ -55,7 +56,10 @@ class Store0Module implements Module {
       frame.i32_const(1);
       frame.i32_store(2, 0);
       frame.i32_const(1);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -67,7 +71,10 @@ class Store0Module implements Module {
       frame.i32_const(0);
       frame.i32_const(1);
       frame.i32_store(2, 0);
-      if (frame.pop() != 0) break block_label_0;
+      if (frame.pop() != 0) {
+        frame.unwindTo(0, 0);
+        break block_label_0;
+      }
     }
   }
 
@@ -82,6 +89,7 @@ class Store0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }

--- a/test/spec/switch/switch.0.dart
+++ b/test/spec/switch/switch.0.dart
@@ -44,22 +44,39 @@ class Switch0Module implements Module {
                         var t0 = frame.pop();
                         switch (t0) {
                           case 0:
+                            frame.unwindTo(0, 0);
                             break block_label_9;
+
                           case 1:
+                            frame.unwindTo(0, 0);
                             break block_label_8;
+
                           case 2:
+                            frame.unwindTo(0, 0);
                             break block_label_7;
+
                           case 3:
+                            frame.unwindTo(0, 0);
                             break block_label_6;
+
                           case 4:
+                            frame.unwindTo(0, 0);
                             break block_label_5;
+
                           case 5:
+                            frame.unwindTo(0, 0);
                             break block_label_4;
+
                           case 6:
+                            frame.unwindTo(0, 0);
                             break block_label_3;
+
                           case 7:
+                            frame.unwindTo(0, 0);
                             break block_label_1;
+
                           default:
+                            frame.unwindTo(0, 0);
                             break block_label_2;
                         }
                       }
@@ -73,12 +90,15 @@ class Switch0Module implements Module {
                 frame.push(i);
                 frame.i32_sub();
                 j = frame.pop();
+                frame.unwindTo(0, 0);
                 break block_label_0;
               }
+              frame.unwindTo(0, 0);
               break block_label_0;
             }
             frame.i32_const(101);
             j = frame.pop();
+            frame.unwindTo(0, 0);
             break block_label_0;
           }
           frame.i32_const(101);
@@ -124,22 +144,39 @@ class Switch0Module implements Module {
                         var t0 = frame.pop();
                         switch (t0) {
                           case 0:
+                            frame.unwindTo(0, 0);
                             break block_label_9;
+
                           case 1:
+                            frame.unwindTo(0, 0);
                             break block_label_8;
+
                           case 2:
+                            frame.unwindTo(0, 0);
                             break block_label_7;
+
                           case 3:
+                            frame.unwindTo(0, 0);
                             break block_label_6;
+
                           case 4:
+                            frame.unwindTo(0, 0);
                             break block_label_3;
+
                           case 5:
+                            frame.unwindTo(0, 0);
                             break block_label_4;
+
                           case 6:
+                            frame.unwindTo(0, 0);
                             break block_label_5;
+
                           case 7:
+                            frame.unwindTo(0, 0);
                             break block_label_1;
+
                           default:
+                            frame.unwindTo(0, 0);
                             break block_label_2;
                         }
                       }
@@ -152,6 +189,7 @@ class Switch0Module implements Module {
                 frame.i64_const(0);
                 frame.push(i);
                 frame.i64_sub();
+                frame.unwindTo(0, 1);
                 break block_label_0;
               }
               frame.i64_const(101);
@@ -160,6 +198,7 @@ class Switch0Module implements Module {
           }
         }
         frame.push(j);
+        frame.unwindTo(0, 1);
         break block_label_0;
       }
       frame.i64_const(-5);
@@ -190,12 +229,19 @@ class Switch0Module implements Module {
             var t0 = frame.pop();
             switch (t0) {
               case 0:
+                frame.unwindTo(2, 1);
                 break block_label_2;
+
               case 1:
+                frame.unwindTo(1, 1);
                 break block_label_1;
+
               case 2:
+                frame.unwindTo(0, 1);
                 break block_label_0;
+
               default:
+                frame.unwindTo(3, 1);
                 break block_label_3;
             }
           }
@@ -217,6 +263,7 @@ class Switch0Module implements Module {
       var t0 = frame.pop();
       switch (t0) {
         default:
+          frame.unwindTo(0, 0);
           break block_label_0;
       }
     }

--- a/test/spec/table_grow/table_grow.4.dart
+++ b/test/spec/table_grow/table_grow.4.dart
@@ -46,11 +46,17 @@ class TableGrow4Module implements Module {
         frame.push(local0);
         frame.ref_is_null();
         frame.i32_eqz();
-        if (frame.pop() != 0) break block_label_0;
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
         frame.push(arg0);
         frame.push(arg1);
         frame.i32_ge_u();
-        if (frame.pop() != 0) break block_label_0;
+        if (frame.pop() != 0) {
+          frame.unwindTo(0, 0);
+          break block_label_0;
+        }
         frame.push(arg0);
         frame.i32_const(1);
         frame.i32_add();
@@ -58,7 +64,9 @@ class TableGrow4Module implements Module {
         frame.push(arg0);
         frame.push(arg1);
         frame.i32_le_u();
-        if (frame.pop() != 0) continue loop_label_1;
+        if (frame.pop() != 0) {
+          continue loop_label_1;
+        }
         break;
       }
     }

--- a/tool/tests.properties
+++ b/tool/tests.properties
@@ -359,8 +359,3 @@ return type_f32_0
 return type_f64_0
 return type_i32_0
 return type_i64_0
-switch arg_0
-switch arg_1
-switch arg_4
-switch arg_5
-switch arg_8


### PR DESCRIPTION
Fix mechanics around block and branch operations:
- add information to track the stack depth for each instruction
- use that when performing forward branches; reset the stack to before the block was entered but retain any block return arguments
- commit (now passing) tests for `br_if`
- this work fixed 5 failing tests for `switch`
- each instruction now knows its immediate args, its stack args, and its stack return values
- track the size of the generated files (larger dart files - ~2MB - expose some algorithmic slowness in the analyzer and vs code)
 