### PR TITLE
update the wasm spec submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "spec"]
 	path = spec
 	url = https://github.com/WebAssembly/spec.git
-	# branch = 1782235239ddebaf2cb079b00fdaa2d2c4dedba3


### PR DESCRIPTION
- update the wasm spec submodule

To move forward past this, we'll need a new version of the `wabt` tools released; that happens on perhaps a monthly cadence.